### PR TITLE
doc: silly typo 16, 19, 24 => 16, 24, 32

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Because you don't have to be an expert to _use_ cryptography!
 
-- Keys can be 128-, 192-, or 256-bit (16, 19, or 24 bytes)
+- Keys can be 128-, 192-, or 256-bit (16, 24, or 32 bytes)
 - Plain input can be raw `Uint8Array`s or (UTF-8) `String`s
 - Encrypted output can be `Base64UrlSafe` Strings, or raw `Uint8Array`s
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cipher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cipher",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/node": "^20.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root/cipher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple AES-GCM cipher codec (for encrypting and decrypting)",
   "main": "cipher.js",
   "files": [


### PR DESCRIPTION
I have no idea how I came up with 19. I can only imagine that I was distracted and copied from 192 or something.

Anyway, this fixes that.