### PR TITLE
fix: passthru static iv on the rest of the functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cipher",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cipher",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/node": "^20.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root/cipher",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple AES-GCM cipher codec (for encrypting and decrypting)",
   "main": "cipher.js",
   "files": [


### PR DESCRIPTION
Static IVs are to be used with great care, but... tests require them, and there are a few other niche uses cases.

This fixes the other functions to accept a staticIv the same as the other 2 - and takes care to not waste cycles on randomizing when it's static.